### PR TITLE
Add "SHARED_ID" pass-through for feature defs

### DIFF
--- a/user-data-processor.py
+++ b/user-data-processor.py
@@ -88,7 +88,7 @@ def main(user_data_config, etl_config_file):
             metadata = {
                 'sample_barcode': file.get('SAMPLEBARCODE', ''),
                 'participant_barcode': file.get('PARTICIPANTBARCODE', ''),
-                'project_id': file.get('USER_PROJECT', ''),
+                'project_id': user_project,
                 'study_id': user_study,
                 'platform': file.get('PLATFORM', ''),
                 'pipeline': file.get('PIPELINE', ''),

--- a/user_gen/cloudsql_table_schemas.py
+++ b/user_gen/cloudsql_table_schemas.py
@@ -45,6 +45,8 @@ def user_feature_def():
          'type': 'VARCHAR(200)'},
         {'column_name': 'bq_map_id',
          'type': 'VARCHAR(200)'},
+        {'column_name': 'shared_map_id',
+         'type': 'VARCHAR(200)'},
         {'column_name': 'is_numeric',
          'type': 'VARCHAR(200)'}
     ]

--- a/user_gen/metadata_updates.py
+++ b/user_gen/metadata_updates.py
@@ -144,11 +144,11 @@ def update_molecular_metadata_samples_list(table, datatype, sample_barcodes):
 '''
 Function to insert one new feature definition
 '''
-def insert_feature_defs(sql_table, study_id, name, bq_mapping, type):
-    insert_stmt = 'INSERT INTO {0} (study_id, feature_name, bq_map_id, is_numeric) VALUES (%s,%s,%s,%s);'
+def insert_feature_defs(sql_table, study_id, name, bq_mapping, shared_map_id, type):
+    insert_stmt = 'INSERT INTO {0} (study_id, feature_name, bq_map_id, shared_map_id, is_numeric) VALUES (%s,%s,%s,%s,%s);'
     db = cloudsql_connector()
     cursor = db.cursor(MySQLdb.cursors.DictCursor)
-    cursor.executemany(insert_stmt, (study_id, name, bq_mapping, type))
+    cursor.executemany(insert_stmt, (study_id, name, bq_mapping, shared_map_id, type))
     db.commit()
     cursor.close()
     db.close()
@@ -157,7 +157,7 @@ def insert_feature_defs(sql_table, study_id, name, bq_mapping, type):
 Function to insert list of new feature definitions
 '''
 def insert_feature_defs_list(sql_table, data_list):
-    insert_stmt = 'INSERT INTO {0} (study_id, feature_name, bq_map_id, is_numeric) VALUES (%s,%s,%s,%s);'.format(sql_table)
+    insert_stmt = 'INSERT INTO {0} (study_id, feature_name, bq_map_id, shared_map_id, is_numeric) VALUES (%s,%s,%s,%s,%s);'.format(sql_table)
     print insert_stmt
     db = cloudsql_connector()
     cursor = db.cursor(MySQLdb.cursors.DictCursor)

--- a/user_gen/molecular_processing.py
+++ b/user_gen/molecular_processing.py
@@ -81,7 +81,7 @@ def parse_file(project_id, bq_dataset, bucket_name, file_data, filename, outfile
     sample_metadata_list = []
     for barcode in sample_barcodes:
         new_metadata = metadata.copy()
-        new_metadata['SampleBarcode'] = barcode
+        new_metadata['sample_barcode'] = barcode
         sample_metadata_list.append(new_metadata)
     update_metadata_data_list(cloudsql_tables['METADATA_DATA'], sample_metadata_list)
 

--- a/user_gen/molecular_processing.py
+++ b/user_gen/molecular_processing.py
@@ -50,7 +50,7 @@ def parse_file(project_id, bq_dataset, bucket_name, file_data, filename, outfile
     map_values = {}
 
     # Get basic column information depending on datatype
-    column_map = get_column_mapping(metadata['DataType'])
+    column_map = get_column_mapping(metadata['data_type'])
 
     # Column headers are sample ids
     for i, j in data_df.iteritems():
@@ -86,11 +86,11 @@ def parse_file(project_id, bq_dataset, bucket_name, file_data, filename, outfile
     update_metadata_data_list(cloudsql_tables['METADATA_DATA'], sample_metadata_list)
 
     # Update metadata_samples table
-    update_molecular_metadata_samples_list(cloudsql_tables['METADATA_SAMPLES'], metadata['DataType'], sample_barcodes)
+    update_molecular_metadata_samples_list(cloudsql_tables['METADATA_SAMPLES'], metadata['data_type'], sample_barcodes)
 
     # Generate feature names and bq_mappings
     table_name = file_data['BIGQUERY_TABLE_NAME']
-    feature_defs = generate_feature_Defs(metadata['DataType'], metadata['Study'], project_id, bq_dataset, table_name, new_df)
+    feature_defs = generate_feature_Defs(metadata['data_type'], metadata['Study'], project_id, bq_dataset, table_name, new_df)
 
     # Update feature_defs table
     insert_feature_defs_list(cloudsql_tables['FEATURE_DEFS'], feature_defs)

--- a/user_gen/molecular_processing.py
+++ b/user_gen/molecular_processing.py
@@ -61,7 +61,7 @@ def parse_file(project_id, bq_dataset, bucket_name, file_data, filename, outfile
             for k, m in j.iteritems():
                 new_df_obj = {}
 
-                new_df_obj['SampleBarcode'] = i
+                new_df_obj['sample_barcode'] = i # Normalized to match user_gen
                 new_df_obj['Project'] = metadata['project_id']
                 new_df_obj['Study'] = metadata['study_id']
                 new_df_obj['Platform'] = metadata['platform']

--- a/user_gen/molecular_processing.py
+++ b/user_gen/molecular_processing.py
@@ -175,11 +175,11 @@ def generate_feature_Defs(datatype, study_id, bq_project, bq_dataset, bq_table, 
         for symbol in unique_symbols:
             feature_name = '{0} {1}'.format(datatype_name_mapping[datatype]['FeatureName'], symbol)
             bqmap = ':'.join([bq_project, bq_dataset, bq_table, datatype_name_mapping[datatype]['BqMapId'], symbol, 'Level'])
-            feature_defs.append((study_id, feature_name, bqmap, None, 'N'))
+            feature_defs.append((study_id, feature_name, bqmap, None, True))
     else:
         feature_name = datatype_name_mapping[datatype]['FeatureName']
         bqmap = ':'.join([bq_project, bq_dataset, bq_table, datatype_name_mapping[datatype]['BqMapId'], 'Level'])
-        feature_defs.append((study_id, feature_name, bqmap, None, 'N'))
+        feature_defs.append((study_id, feature_name, bqmap, None, True))
 
     return feature_defs
 

--- a/user_gen/molecular_processing.py
+++ b/user_gen/molecular_processing.py
@@ -175,11 +175,11 @@ def generate_feature_Defs(datatype, study_id, bq_project, bq_dataset, bq_table, 
         for symbol in unique_symbols:
             feature_name = '{0} {1}'.format(datatype_name_mapping[datatype]['FeatureName'], symbol)
             bqmap = ':'.join([bq_project, bq_dataset, bq_table, datatype_name_mapping[datatype]['BqMapId'], symbol, 'Level'])
-            feature_defs.append((study_id, feature_name, bqmap, 'N'))
+            feature_defs.append((study_id, feature_name, bqmap, None, 'N'))
     else:
         feature_name = datatype_name_mapping[datatype]['FeatureName']
         bqmap = ':'.join([bq_project, bq_dataset, bq_table, datatype_name_mapping[datatype]['BqMapId'], 'Level'])
-        feature_defs.append((study_id, feature_name, bqmap, 'N'))
+        feature_defs.append((study_id, feature_name, bqmap, None, 'N'))
 
     return feature_defs
 

--- a/user_gen/molecular_processing.py
+++ b/user_gen/molecular_processing.py
@@ -97,7 +97,7 @@ def parse_file(project_id, bq_dataset, bucket_name, file_data, filename, outfile
 
     # upload the contents of the dataframe in njson format
     tmp_bucket = os.environ.get('tmp_bucket_location')
-    gcs.convert_df_to_njson_and_upload(new_df, outfilename, metadata=metadata, tmp_bucket='isb-cgc-dev')
+    gcs.convert_df_to_njson_and_upload(new_df, outfilename, metadata=metadata, tmp_bucket=tmp_bucket)
 
     # Load into BigQuery
     # Using temporary file location (in case we don't have write permissions on user's bucket?)

--- a/user_gen/molecular_processing.py
+++ b/user_gen/molecular_processing.py
@@ -90,7 +90,7 @@ def parse_file(project_id, bq_dataset, bucket_name, file_data, filename, outfile
 
     # Generate feature names and bq_mappings
     table_name = file_data['BIGQUERY_TABLE_NAME']
-    feature_defs = generate_feature_Defs(metadata['data_type'], metadata['Study'], project_id, bq_dataset, table_name, new_df)
+    feature_defs = generate_feature_Defs(metadata['data_type'], metadata['study_id'], project_id, bq_dataset, table_name, new_df)
 
     # Update feature_defs table
     insert_feature_defs_list(cloudsql_tables['FEATURE_DEFS'], feature_defs)

--- a/user_gen/user_gen_processing.py
+++ b/user_gen/user_gen_processing.py
@@ -157,7 +157,7 @@ def generate_bq_schema(columns):
                 type = 'FLOAT'
             else:
                 type = 'INTEGER'
-            obj.append({'name': column['NAME'], 'type': type})
+            obj.append({'name': column['NAME'], 'type': type, 'shared_id': column['SHARED_ID']})
     return obj
 
 
@@ -176,7 +176,7 @@ def generate_feature_defs(study_id, bq_project, bq_dataset, bq_table, schema):
                 datatype = 0
             else:
                 datatype = 1
-            feature_defs.append((study_id, feature_name, bq_map, datatype))
+            feature_defs.append((study_id, feature_name, bq_map, column['shared_id'], datatype))
     return feature_defs
 
 if __name__ == '__main__':


### PR DESCRIPTION
We needed to pass through a "shared" id to identify if a column can be mapped to a data dictionary value. For example, this may be `"CLIN:vital_status"` if it relates to the TCGA vital status data dictionary item.

Eventually this could also be used for extending other uploaded study data, but that is not supported in the UI or in the API access at this point.

Also included are fixes for some issues discovered while testing molecular data processing. Both should now be up to date and working.
## NOTE

You will not want to take this pull request until you take the pull request that includes querying user data. That is because this assumes that tables created by the webapp side have a "shared_map_id" column.
